### PR TITLE
[stdlib] Add iterator for LinkedList

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -55,6 +55,16 @@ what we publish.
 - Added a `StringSlice.is_codepoint_boundary()` method for querying if a given
   byte index is a boundary between encoded UTF-8 codepoints.
 
+- Added an iterator to `LinkedList` ([PR #4005](https://github.com/modular/mojo/pull/4005))
+  - `LinkedList.__iter__()` to create a forward iterator.
+  - `LinkedList.__reversed__()` for a backward iterator.
+
+  ```mojo
+  var ll = LinkedList[Int](1, 2, 3)
+  for element in ll:
+    print(element[])
+  ```
+
 ### GPU changes
 
 - `ctx.enqueue_function(compiled_func, ...)` is deprecated:

--- a/stdlib/test/collections/test_linked_list.mojo
+++ b/stdlib/test/collections/test_linked_list.mojo
@@ -544,6 +544,39 @@ def test_list_dtor():
     assert_equal(g_dtor_count, 1)
 
 
+def test_iter():
+    var l = LinkedList[Int](1, 2, 3)
+    var iter = l.__iter__()
+    assert_true(iter.__has_next__(), "Expected iter to have next")
+    assert_equal(len(iter), 3)
+    assert_equal(iter.__next__()[], 1)
+    assert_equal(iter.__next__()[], 2)
+    assert_equal(len(iter), 1)
+    assert_equal(iter.__next__()[], 3)
+    assert_equal(len(iter), 0)
+    assert_false(iter.__has_next__(), "Expected iter to not have next")
+
+    var riter = l.__reversed__()
+    assert_true(riter.__has_next__(), "Expected iter to have next")
+    assert_equal(len(riter), 3)
+    assert_equal(riter.__next__()[], 3)
+    assert_equal(riter.__next__()[], 2)
+    assert_equal(len(riter), 1)
+    assert_equal(riter.__next__()[], 1)
+    assert_equal(len(riter), 0)
+    assert_false(riter.__has_next__(), "Expected iter to not have next")
+
+    var i = 0
+    for el in l:
+        assert_equal(el[], l[i])
+        i += 1
+
+    i = 2
+    for el in l.__reversed__():
+        assert_equal(el[], l[i])
+        i -= 1
+
+
 def main():
     test_construction()
     test_append()
@@ -574,3 +607,4 @@ def main():
     test_list_dtor()
     test_list_insert()
     test_list_eq_ne()
+    test_iter()


### PR DESCRIPTION
There was some previous discussion about whether casting the lifetime of the list elements in this manner was sound, but now that 25.1 is out the door I think we can revisit this?

From my understanding the lifetime of the list elements should be the same as the list itself so it _should_ be fine to do it this way?
