### PR TITLE
[stdlib] Vectorize `_memr*` functions and use `Span`

### DIFF
--- a/mojo/stdlib/benchmarks/collections/bench_string.mojo
+++ b/mojo/stdlib/benchmarks/collections/bench_string.mojo
@@ -255,6 +255,26 @@ def bench_string_find_single[
 
 
 # ===-----------------------------------------------------------------------===#
+# Benchmark string rfind single
+# ===-----------------------------------------------------------------------===#
+@parameter
+def bench_string_rfind_single[
+    length: Int = 0, filename: StaticString = "UN_charter_EN"
+](mut b: Bencher) raises:
+    var items = make_string[length](filename + ".txt")
+
+    @always_inline
+    @parameter
+    def call_fn() raises:
+        for _ in range(10**6 // length):
+            var res = items.rfind("Z")  # something that probably won't be there
+            keep(res)
+
+    b.iter[call_fn]()
+    keep(Bool(items))
+
+
+# ===-----------------------------------------------------------------------===#
 # Benchmark string find multiple
 # ===-----------------------------------------------------------------------===#
 @parameter
@@ -272,6 +292,28 @@ def bench_string_find_multiple[
             keep(res)
 
     b.iter(call_fn)
+
+
+# ===-----------------------------------------------------------------------===#
+# Benchmark string rfind multiple
+# ===-----------------------------------------------------------------------===#
+@parameter
+def bench_string_rfind_multiple[
+    length: Int = 0, filename: StaticString = "UN_charter_EN"
+](mut b: Bencher) raises:
+    var items = make_string[length](filename + ".txt")
+    var sequence = "ZZZZ"  # something that probably won't be there
+
+    @always_inline
+    @parameter
+    def call_fn() raises:
+        for _ in range(10**6 // length):
+            var res = items.rfind(sequence)
+            keep(res)
+
+    b.iter[call_fn]()
+    keep(Bool(items))
+    keep(Bool(sequence))
 
 
 # ===-----------------------------------------------------------------------===#
@@ -473,6 +515,12 @@ def main() raises:
             )
             m.bench_function[bench_string_find_multiple[length, fname]](
                 BenchId(String("bench_string_find_multiple", suffix))
+            )
+            m.bench_function[bench_string_rfind_single[length, fname]](
+                BenchId(String("bench_string_rfind_single", suffix))
+            )
+            m.bench_function[bench_string_rfind_multiple[length, fname]](
+                BenchId(String("bench_string_rfind_multiple", suffix))
             )
             m.bench_function[bench_string_is_valid_utf8[length, fname]](
                 BenchId(String("bench_string_is_valid_utf8", suffix))

--- a/mojo/stdlib/std/collections/string/string_slice.mojo
+++ b/mojo/stdlib/std/collections/string/string_slice.mojo
@@ -40,7 +40,7 @@ from std.sys import simd_width_of
 from std.ffi import c_char, CStringSlice
 from std.sys.intrinsics import likely, unlikely
 
-from std.bit import count_trailing_zeros
+from std.bit import count_trailing_zeros, count_leading_zeros
 from std.bit.mask import is_negative, splat
 from std.memory import (
     Span,
@@ -1480,12 +1480,9 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut=mut]](
 
         # The substring to search within, offset from the beginning if `start`
         # is positive, and offset from the end if `start` is negative.
-        var haystack = self.as_bytes()[start:]
+        var haystack = self.as_bytes()[start:].get_immutable()
 
-        var loc = _memmem(
-            haystack.get_immutable(),
-            substr.as_bytes().get_immutable(),
-        )
+        var loc = _memmem(haystack, substr.as_bytes().get_immutable())
 
         if not loc:
             return -1
@@ -1512,12 +1509,9 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut=mut]](
 
         # The substring to search within, offset from the beginning if `start`
         # is positive, and offset from the end if `start` is negative.
-        var haystack = self.as_bytes()[start:]
+        var haystack = self.as_bytes()[start:].get_immutable()
 
-        var loc = _memrmem(
-            haystack,
-            substr.as_bytes(),
-        )
+        var loc = _memrmem(haystack, substr.as_bytes().get_immutable())
 
         if not loc:
             return -1
@@ -2364,45 +2358,111 @@ def _memmem_impl[
 
 @always_inline
 def _memrchr[
-    dtype: DType
+    dtype: DType, //
 ](
-    source: Span[mut=False, Scalar[dtype], _],
+    span: Span[mut=False, Scalar[dtype], ...],
     char: Scalar[dtype],
-) -> Optional[
-    UnsafePointer[Scalar[dtype], source.origin]
-]:
-    for i in reversed(range(len(source))):
-        if source.unsafe_get(i) == char:
-            return source.unsafe_ptr() + i
-    return {}
+    out output: Optional[type_of(span.unsafe_ptr())],
+):
+    var haystack = span.unsafe_ptr()
+    var length = len(span)
+    comptime bool_mask_width = simd_width_of[DType.bool]()
+    if __is_run_in_comptime_interpreter or length < bool_mask_width:
+        for i in reversed(range(length)):
+            if haystack[i] == char:
+                output = haystack + i
+                return
+        output = None
+        return
+
+    var vectorized_end = align_down(length, bool_mask_width)
+
+    for i in reversed(range(vectorized_end, length)):
+        if haystack[i] == char:
+            output = haystack + i
+            return
+
+    var first_needle = SIMD[dtype, bool_mask_width](char)
+    for i in reversed(range(0, vectorized_end, bool_mask_width)):
+        var bool_mask = haystack.load[width=bool_mask_width](i).eq(first_needle)
+        var mask = pack_bits(bool_mask)
+        if mask:
+            var zeros = Int(count_leading_zeros(mask)) + 1
+            output = haystack + (i + bool_mask_width - zeros)
+            return
+
+    output = None
 
 
 @always_inline
 def _memrmem[
-    dtype: DType
+    dtype: DType, //
 ](
-    haystack: Span[mut=False, Scalar[dtype], _],
-    needle: Span[mut=False, Scalar[dtype], _],
-) -> Optional[UnsafePointer[Scalar[dtype], haystack.origin]]:
-    if not needle:
-        return haystack.unsafe_ptr()
-    if len(needle) > len(haystack):
-        return {}
-    if len(needle) == 1:
-        return _memrchr[dtype](haystack, needle.unsafe_get(0))
-    for i in reversed(range(len(haystack) - len(needle) + 1)):
-        if haystack.unsafe_get(i) != needle.unsafe_get(0):
+    haystack_span: Span[mut=False, Scalar[dtype], ...],
+    needle_span: Span[mut=False, Scalar[dtype], ...],
+    out output: Optional[type_of(haystack_span.unsafe_ptr())],
+):
+    var haystack = haystack_span.unsafe_ptr()
+    var haystack_len = len(haystack_span)
+    var needle = needle_span.unsafe_ptr()
+    var needle_len = len(needle_span)
+
+    if needle_len == 0:
+        output = haystack
+        return
+    elif haystack_len == 0 or needle_len > haystack_len:
+        output = None
+        return
+    elif needle_len == 1:
+        output = _memrchr(haystack_span, needle[0])
+        return
+
+    comptime bool_mask_width = simd_width_of[DType.bool]()
+    var length = haystack_len - needle_len + 1
+
+    if __is_run_in_comptime_interpreter or haystack_len < bool_mask_width:
+        for i in reversed(range(length)):
+            if haystack[i] != needle[0]:
+                continue
+
+            if memcmp(haystack + i + 1, needle + 1, needle_len - 1) == 0:
+                output = haystack + i
+                return
+        output = None
+        return
+
+    var vectorized_end = align_down(length, bool_mask_width)
+
+    for i in reversed(range(vectorized_end, length)):
+        if haystack[i] != needle[0]:
             continue
-        if (
-            memcmp(
-                haystack.unsafe_ptr() + i + 1,
-                needle.unsafe_ptr() + 1,
-                len(needle) - 1,
-            )
-            == 0
-        ):
-            return haystack.unsafe_ptr() + i
-    return {}
+
+        if memcmp(haystack + i + 1, needle + 1, needle_len - 1) == 0:
+            output = haystack + i
+            return
+
+    var first_needle = SIMD[dtype, bool_mask_width](needle[0])
+    var last_needle = SIMD[dtype, bool_mask_width](needle[needle_len - 1])
+
+    for i in reversed(range(0, vectorized_end, bool_mask_width)):
+        var first_block = haystack.load[width=bool_mask_width](i)
+        var last_block = haystack.load[width=bool_mask_width](
+            i + needle_len - 1
+        )
+
+        var bool_mask = first_needle.eq(first_block) & last_needle.eq(
+            last_block
+        )
+        var mask = pack_bits(bool_mask)
+
+        while mask:
+            var offset = i + bool_mask_width - Int(count_leading_zeros(mask))
+            if memcmp(haystack + offset, needle + 1, needle_len - 1) == 0:
+                output = haystack + offset - 1
+                return
+            mask = mask & (mask - 1)
+
+    output = None
 
 
 def _split[

--- a/mojo/stdlib/std/collections/string/string_slice.mojo
+++ b/mojo/stdlib/std/collections/string/string_slice.mojo
@@ -45,7 +45,7 @@ from std.sys import simd_width_of
 from std.ffi import c_char, CStringSlice
 from std.sys.intrinsics import likely, unlikely
 
-from std.bit import count_trailing_zeros
+from std.bit import count_trailing_zeros, count_leading_zeros
 from std.bit.mask import is_negative, splat
 from std.memory import (
     Span,
@@ -1752,12 +1752,9 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut=mut]](
 
         # The substring to search within, offset from the beginning if `start`
         # is positive, and offset from the end if `start` is negative.
-        var haystack = self.as_bytes()[start:]
+        var haystack = self.as_bytes()[start:].get_immutable()
 
-        var loc = _memmem(
-            haystack.get_immutable(),
-            substr.as_bytes().get_immutable(),
-        )
+        var loc = _memmem(haystack, substr.as_bytes().get_immutable())
 
         if not loc:
             return -1
@@ -1784,12 +1781,9 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut=mut]](
 
         # The substring to search within, offset from the beginning if `start`
         # is positive, and offset from the end if `start` is negative.
-        var haystack = self.as_bytes()[start:]
+        var haystack = self.as_bytes()[start:].get_immutable()
 
-        var loc = _memrmem(
-            haystack,
-            substr.as_bytes(),
-        )
+        var loc = _memrmem(haystack, substr.as_bytes().get_immutable())
 
         if not loc:
             return -1
@@ -2636,45 +2630,111 @@ def _memmem_impl[
 
 @always_inline
 def _memrchr[
-    dtype: DType
+    dtype: DType, //
 ](
-    source: Span[mut=False, Scalar[dtype], _],
+    span: Span[mut=False, Scalar[dtype], ...],
     char: Scalar[dtype],
-) -> Optional[
-    UnsafePointer[Scalar[dtype], source.origin]
-]:
-    for i in reversed(range(len(source))):
-        if source.unsafe_get(i) == char:
-            return source.unsafe_ptr() + i
-    return {}
+    out output: Optional[type_of(span.unsafe_ptr())],
+):
+    var haystack = span.unsafe_ptr()
+    var length = len(span)
+    comptime bool_mask_width = simd_width_of[DType.bool]()
+    if __is_run_in_comptime_interpreter or length < bool_mask_width:
+        for i in reversed(range(length)):
+            if haystack[i] == char:
+                output = haystack + i
+                return
+        output = None
+        return
+
+    var vectorized_end = align_down(length, bool_mask_width)
+
+    for i in reversed(range(vectorized_end, length)):
+        if haystack[i] == char:
+            output = haystack + i
+            return
+
+    var first_needle = SIMD[dtype, bool_mask_width](char)
+    for i in reversed(range(0, vectorized_end, bool_mask_width)):
+        var bool_mask = haystack.load[width=bool_mask_width](i).eq(first_needle)
+        var mask = pack_bits(bool_mask)
+        if mask:
+            var zeros = Int(count_leading_zeros(mask)) + 1
+            output = haystack + (i + bool_mask_width - zeros)
+            return
+
+    output = None
 
 
 @always_inline
 def _memrmem[
-    dtype: DType
+    dtype: DType, //
 ](
-    haystack: Span[mut=False, Scalar[dtype], _],
-    needle: Span[mut=False, Scalar[dtype], _],
-) -> Optional[UnsafePointer[Scalar[dtype], haystack.origin]]:
-    if not needle:
-        return haystack.unsafe_ptr()
-    if len(needle) > len(haystack):
-        return {}
-    if len(needle) == 1:
-        return _memrchr[dtype](haystack, needle.unsafe_get(0))
-    for i in reversed(range(len(haystack) - len(needle) + 1)):
-        if haystack.unsafe_get(i) != needle.unsafe_get(0):
+    haystack_span: Span[mut=False, Scalar[dtype], ...],
+    needle_span: Span[mut=False, Scalar[dtype], ...],
+    out output: Optional[type_of(haystack_span.unsafe_ptr())],
+):
+    var haystack = haystack_span.unsafe_ptr()
+    var haystack_len = len(haystack_span)
+    var needle = needle_span.unsafe_ptr()
+    var needle_len = len(needle_span)
+
+    if needle_len == 0:
+        output = haystack
+        return
+    elif haystack_len == 0 or needle_len > haystack_len:
+        output = None
+        return
+    elif needle_len == 1:
+        output = _memrchr(haystack_span, needle[0])
+        return
+
+    comptime bool_mask_width = simd_width_of[DType.bool]()
+    var length = haystack_len - needle_len + 1
+
+    if __is_run_in_comptime_interpreter or haystack_len < bool_mask_width:
+        for i in reversed(range(length)):
+            if haystack[i] != needle[0]:
+                continue
+
+            if memcmp(haystack + i + 1, needle + 1, needle_len - 1) == 0:
+                output = haystack + i
+                return
+        output = None
+        return
+
+    var vectorized_end = align_down(length, bool_mask_width)
+
+    for i in reversed(range(vectorized_end, length)):
+        if haystack[i] != needle[0]:
             continue
-        if (
-            memcmp(
-                haystack.unsafe_ptr() + i + 1,
-                needle.unsafe_ptr() + 1,
-                len(needle) - 1,
-            )
-            == 0
-        ):
-            return haystack.unsafe_ptr() + i
-    return {}
+
+        if memcmp(haystack + i + 1, needle + 1, needle_len - 1) == 0:
+            output = haystack + i
+            return
+
+    var first_needle = SIMD[dtype, bool_mask_width](needle[0])
+    var last_needle = SIMD[dtype, bool_mask_width](needle[needle_len - 1])
+
+    for i in reversed(range(0, vectorized_end, bool_mask_width)):
+        var first_block = haystack.load[width=bool_mask_width](i)
+        var last_block = haystack.load[width=bool_mask_width](
+            i + needle_len - 1
+        )
+
+        var bool_mask = first_needle.eq(first_block) & last_needle.eq(
+            last_block
+        )
+        var mask = pack_bits(bool_mask)
+
+        while mask:
+            var offset = i + bool_mask_width - Int(count_leading_zeros(mask))
+            if memcmp(haystack + offset, needle + 1, needle_len - 1) == 0:
+                output = haystack + offset - 1
+                return
+            mask = mask & (mask - 1)
+
+    output = None
 
 
 def _split[


### PR DESCRIPTION
Vectorize `_memr*` functions and use `Span`.

This is a split-off from PR  #3548. Part of #4758

### Benchmarks

Intel i7-7700HQ

  | old value (ms) | new value (ms) | markdown percentage
-- | -- | -- | --
bench_string_rfind_single[10] | 7.20379814110429 | 7.18222169503546 | 0.0030
bench_string_rfind_multiple[10] | 7.59569340127389 | 13.9638786506024 | -0.8384
bench_string_rfind_single[30] | 17.7615220952381 | 14.1915136144578 | 0.2010
bench_string_rfind_multiple[30] | 21.6381638444444 | 31.5070153947368 | -0.4561
bench_string_rfind_single[50] | 35.7993967941176 | 13.8713651034483 | 0.6125
bench_string_rfind_multiple[50] | 38.1559159142857 | 21.6044696481481 | 0.4338
bench_string_rfind_single[100] | 75.9544176153846 | 7.16647223076923 | 0.9056
bench_string_rfind_multiple[100] | 82.24730125 | 15.1798472 | 0.8154
bench_string_rfind_single[1000] | 558.9741905 | 22.3311269074074 | 0.9600
bench_string_rfind_multiple[1000] | 689.452217 | 49.7513309130435 | 0.9278
bench_string_rfind_single[10000] | 7092.1658335 | 169.293061285714 | 0.9761
bench_string_rfind_multiple[10000] | 6871.76031 | 387.115135 | 0.9437
  |   | Average | 0.4570


