### PR TITLE
[stdlib] Mark struct fields reflection apis as `@always_inline("builtin")` where possible

### DIFF
--- a/mojo/stdlib/std/reflection/struct_fields.mojo
+++ b/mojo/stdlib/std/reflection/struct_fields.mojo
@@ -98,6 +98,7 @@ def main():
 from std.sys.info import _current_target, _TargetType
 
 
+@always_inline("builtin")
 def struct_field_index_by_name[
     T: AnyType,
     name: StringLiteral,
@@ -148,12 +149,13 @@ struct ReflectedType[T: AnyType](TrivialRegisterPassable):
         ```
     """
 
-    @always_inline("nodebug")
+    @always_inline("builtin")
     def __init__(out self):
         """Create a ReflectedType instance."""
         pass
 
 
+@always_inline("builtin")
 def struct_field_type_by_name[
     StructT: AnyType,
     name: StringLiteral,
@@ -226,6 +228,7 @@ def struct_field_type_by_name[
 # ===----------------------------------------------------------------------=== #
 
 
+@always_inline("builtin")
 def struct_field_count[T: AnyType]() -> Int:
     """Returns the number of fields in struct `T`.
 
@@ -266,6 +269,7 @@ def struct_field_count[T: AnyType]() -> Int:
     )
 
 
+@always_inline("builtin")
 def struct_field_types[
     T: AnyType,
 ]() -> Variadic.TypesOfTrait[AnyType]:
@@ -307,6 +311,7 @@ def struct_field_types[
     return __struct_field_types(T)
 
 
+@always_inline("builtin")
 def _struct_field_names_raw[
     T: AnyType,
 ]() -> __mlir_type[`!kgen.variadic<!kgen.string>`]:
@@ -363,6 +368,7 @@ def struct_field_names[
     return result^
 
 
+@always_inline("builtin")
 def is_struct_type[T: AnyType]() -> Bool:
     """Returns `True` if `T` is a Mojo struct type, `False` otherwise.
 
@@ -422,6 +428,7 @@ def is_struct_type[T: AnyType]() -> Bool:
 # ===----------------------------------------------------------------------=== #
 
 
+@always_inline("builtin")
 def _struct_field_offset_by_index[
     T: AnyType, idx: Int, target: _TargetType = _current_target()
 ]() -> Int:
@@ -440,6 +447,7 @@ def _struct_field_offset_by_index[
     )
 
 
+@always_inline("builtin")
 def _struct_field_offset_by_name[
     T: AnyType, name: StringLiteral, target: _TargetType = _current_target()
 ]() -> Int:
@@ -460,6 +468,7 @@ def _struct_field_offset_by_name[
     )
 
 
+@always_inline("builtin")
 def offset_of[
     T: AnyType, *, name: StringLiteral, target: _TargetType = _current_target()
 ]() -> Int:
@@ -499,6 +508,7 @@ def offset_of[
     return _struct_field_offset_by_name[T, name, target]()
 
 
+@always_inline("builtin")
 def offset_of[
     T: AnyType, *, index: Int, target: _TargetType = _current_target()
 ]() -> Int:

--- a/mojo/stdlib/std/sys/info.mojo
+++ b/mojo/stdlib/std/sys/info.mojo
@@ -27,7 +27,7 @@ from std.ffi import _external_call_const, external_call
 comptime _TargetType = __mlir_type.`!kgen.target`
 
 
-@always_inline("nodebug")
+@always_inline("builtin")
 def _current_target() -> _TargetType:
     return __mlir_attr.`#kgen.param.expr<current_target> : !kgen.target`
 

--- a/mojo/stdlib/test/reflection/test_struct_fields.mojo
+++ b/mojo/stdlib/test/reflection/test_struct_fields.mojo
@@ -24,6 +24,7 @@ from std.reflection import (
 )
 from std.testing import assert_equal, assert_true, assert_false
 from std.testing import TestSuite
+from std.sys.intrinsics import _type_is_eq_parse_time
 
 
 # ===----------------------------------------------------------------------=== #
@@ -390,6 +391,21 @@ def test_struct_field_types_are_correct() raises:
     assert_equal(get_type_name[types[1]](), "SIMD[DType.float64, 1]")
 
 
+@fieldwise_init
+struct HasIntField[
+    T: AnyType where Variadic.contains[
+        Trait=AnyType, Int, struct_field_types[T]()
+    ]
+]:
+    pass
+
+
+def test_struct_field_types_where_clause() raises:
+    # Test that struct_field_types can be used in a where clause for constraints
+    # This is a compile-time test - if it compiles, it works.
+    _ = HasIntField[SimpleStruct]()
+
+
 # ===----------------------------------------------------------------------=== #
 # Field Index and Type by Name Tests
 # ===----------------------------------------------------------------------=== #
@@ -475,6 +491,20 @@ def test_struct_field_type_matches_index() raises:
     assert_equal(get_type_name[y_type_by_idx](), "SIMD[DType.float64, 1]")
 
 
+@fieldwise_init
+struct StructFieldIndexConstrained[
+    T: AnyType,
+    Field: StringLiteral where struct_field_index_by_name[T, Field]() >= 1,
+]:
+    pass
+
+
+def test_struct_field_index_by_name_in_where_clause() raises:
+    # Test that struct_field_index_by_name can be used in a where clause for constraints
+    # This is a compile-time test - if it compiles, it works.
+    _ = StructFieldIndexConstrained[SimpleStruct, "y"]()
+
+
 # ===----------------------------------------------------------------------=== #
 # Field Type by Name Tests (using ReflectedType wrapper)
 # ===----------------------------------------------------------------------=== #
@@ -540,6 +570,22 @@ def test_struct_field_type_by_name_parametric_struct() raises:
     list_value.append(2)
     list_value.append(3)
     assert_equal(len(list_value), 3)
+
+
+@fieldwise_init
+struct StructFieldTypeConstrained[
+    T: AnyType,
+    Field: StringLiteral where _type_is_eq_parse_time[
+        struct_field_type_by_name[T, Field]().T, Int
+    ](),
+]:
+    pass
+
+
+def test_struct_field_type_by_name_where_clause() raises:
+    # Test that struct_field_type_by_name can be used in a where clause for constraints
+    # This is a compile-time test - if it compiles, it works.
+    _ = StructFieldTypeConstrained[GenericTestPoint, "x"]()
 
 
 # ===----------------------------------------------------------------------=== #
@@ -660,6 +706,19 @@ def test_generic_with_parametric_struct() raises:
     # Test generic function instantiated with different parameter values
     assert_equal(generic_parametric_inspector[Int, 5](), 2)
     assert_equal(generic_parametric_inspector[Float64, 100](), 2)
+
+
+@fieldwise_init
+struct StructWithFieldCountConstraint[
+    T: AnyType, Count: Int where struct_field_count[T]() == 3
+]:
+    pass
+
+
+def test_struct_field_count_where_clause() raises:
+    # Test that struct_field_count can be used in a where clause for constraints
+    # This is a compile-time test - if it compiles, it works.
+    _ = StructWithFieldCountConstraint[GenericTestPoint, 3]()
 
 
 # ===----------------------------------------------------------------------=== #


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Your contribution is appreciated.

Please fill out the sections below to help reviewers understand your change.
For guidance on writing a good PR, see our
[contributor guide](../CONTRIBUTING.md).
-->

## Summary

<!-- Describe what this PR does and why. Link to any related issues. -->

Marking these functions with `@always_inline("builtin")` should be beneficial for compile times, and will allow them to be used in `where` statements

## Testing

<!--
Describe how you validated your changes. For code changes, this should include
what tests you ran and any relevant results. For documentation changes, describe
how you verified accuracy.
-->

Stdlib tests pass, which should be sufficient as this does not affect functionality, only compiler behaviour.

## Checklist

- [x] PR is small and focused — consider splitting larger changes into a
      sequence of smaller PRs
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [ ] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description
      (see [AI Tool Use Policy](../AI_TOOL_POLICY.md))
