### PR TITLE
[stdlib] Add docstring examples to base64 functions

### DIFF
--- a/mojo/stdlib/std/base64/base64.mojo
+++ b/mojo/stdlib/std/base64/base64.mojo
@@ -102,6 +102,13 @@ def b64encode(input_string: StringSlice[mut=False, _]) -> String:
 
     Returns:
         The ASCII base64 encoded string.
+
+    Example:
+    ```mojo
+    from std.base64 import b64encode
+
+    print(b64encode("Hello"))  # SGVsbG8=
+    ```
     """
     return b64encode(input_string.as_bytes())
 
@@ -142,6 +149,13 @@ def b64decode[
 
     Raises:
         If the operation fails.
+
+    Example:
+    ```mojo
+    from std.base64 import b64decode
+
+    print(b64decode("SGVsbG8="))  # Hello
+    ```
     """
     comptime `=` = Byte(ord("="))
     var data = str.as_bytes()
@@ -186,6 +200,13 @@ def b16encode(str: StringSlice[mut=False, _]) -> String:
 
     Returns:
         Base16 encoding of the input string.
+
+    Example:
+    ```mojo
+    from std.base64 import b16encode
+
+    print(b16encode("Hi"))  # 4869
+    ```
     """
     comptime lookup = "0123456789ABCDEF"
     var b16chars = lookup.unsafe_ptr()
@@ -217,6 +238,13 @@ def b16decode(str: StringSlice[mut=False, _]) -> String:
 
     Returns:
         The decoded string.
+
+    Example:
+    ```mojo
+    from std.base64 import b16decode
+
+    print(b16decode("4869"))  # Hi
+    ```
     """
 
     comptime `A` = Byte(ord("A"))


### PR DESCRIPTION
Partial fix for #3572

## Summary
- Adds examples to `b64encode`, `b64decode`, `b16encode`, `b16decode` in `base64/base64.mojo`

## Testing
- `./bazelw test //mojo/stdlib/std:std.docs_test` — passes
- `./bazelw run //:lint` — passes

## Checklist
- [x] PR is small and focused
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an `Assisted-by:` trailer in my commit message or this PR description (see [AI Tool Use Policy](../AI_TOOL_POLICY.md))