### PR TITLE
[stdlib] Add docstring examples to Set methods

### DIFF
--- a/mojo/stdlib/std/collections/set.mojo
+++ b/mojo/stdlib/std/collections/set.mojo
@@ -125,6 +125,15 @@ struct Set[T: KeyElement, H: Hasher = default_hasher](
 
         Returns:
             Whether or not the set contains the element.
+
+        Example:
+        ```mojo
+        from std.collections import Set
+
+        var s = Set[Int](1, 2, 3)
+        print(2 in s)   # True
+        print(99 in s)  # False
+        ```
         """
         return t in self._data
 
@@ -393,6 +402,15 @@ struct Set[T: KeyElement, H: Hasher = default_hasher](
 
         Args:
             t: The element to add to the set.
+
+        Example:
+        ```mojo
+        from std.collections import Set
+
+        var s = Set[Int](1, 2)
+        s.add(3)
+        print(len(s))  # 3
+        ```
         """
         self._data[t.copy()] = None
 
@@ -404,6 +422,15 @@ struct Set[T: KeyElement, H: Hasher = default_hasher](
 
         Raises:
             If the element isn't in the set to remove.
+
+        Example:
+        ```mojo
+        from std.collections import Set
+
+        var s = Set[Int](1, 2, 3)
+        s.remove(2)
+        print(len(s))  # 2
+        ```
         """
         self._data.pop(t)
 
@@ -433,6 +460,15 @@ struct Set[T: KeyElement, H: Hasher = default_hasher](
         Returns:
             A new set containing any elements which appear in either
             this set or the `other` set.
+
+        Example:
+        ```mojo
+        from std.collections import Set
+
+        var a = Set[Int](1, 2)
+        var b = Set[Int](2, 3)
+        var c = a.union(b)  # {1, 2, 3}
+        ```
         """
         var result = self.copy()
         for o in other:
@@ -449,6 +485,15 @@ struct Set[T: KeyElement, H: Hasher = default_hasher](
         Returns:
             A new set containing only the elements which appear in both
             this set and the `other` set.
+
+        Example:
+        ```mojo
+        from std.collections import Set
+
+        var a = Set[Int](1, 2, 3)
+        var b = Set[Int](2, 3, 4)
+        var c = a.intersection(b)  # {2, 3}
+        ```
         """
         var result = Set[Self.T, Self.H]()
         for v in self:
@@ -466,6 +511,15 @@ struct Set[T: KeyElement, H: Hasher = default_hasher](
         Returns:
             A new set containing elements that are in this set but not in
             the `other` set.
+
+        Example:
+        ```mojo
+        from std.collections import Set
+
+        var a = Set[Int](1, 2, 3)
+        var b = Set[Int](2, 3, 4)
+        var c = a.difference(b)  # {1}
+        ```
         """
         var result = Set[Self.T, Self.H]()
         for e in self:
@@ -534,6 +588,16 @@ struct Set[T: KeyElement, H: Hasher = default_hasher](
 
         Returns:
             True if this set is a subset of the `other` set, False otherwise.
+
+        Example:
+        ```mojo
+        from std.collections import Set
+
+        var a = Set[Int](1, 2)
+        var b = Set[Int](1, 2, 3)
+        print(a.issubset(b))  # True
+        print(b.issubset(a))  # False
+        ```
         """
         if len(self) > len(other):
             return False
@@ -552,6 +616,15 @@ struct Set[T: KeyElement, H: Hasher = default_hasher](
 
         Returns:
             True if this set is disjoint with the `other` set, False otherwise.
+
+        Example:
+        ```mojo
+        from std.collections import Set
+
+        var a = Set[Int](1, 2)
+        var b = Set[Int](3, 4)
+        print(a.isdisjoint(b))  # True
+        ```
         """
         for element in self:
             if element in other:
@@ -585,6 +658,15 @@ struct Set[T: KeyElement, H: Hasher = default_hasher](
 
         Returns:
             A new set containing the symmetric difference of the two sets.
+
+        Example:
+        ```mojo
+        from std.collections import Set
+
+        var a = Set[Int](1, 2, 3)
+        var b = Set[Int](2, 3, 4)
+        var c = a.symmetric_difference(b)  # {1, 4}
+        ```
         """
         var result = Set[Self.T, Self.H]()
 
@@ -611,6 +693,15 @@ struct Set[T: KeyElement, H: Hasher = default_hasher](
 
         Args:
             value: The element to remove from the set.
+
+        Example:
+        ```mojo
+        from std.collections import Set
+
+        var s = Set[Int](1, 2, 3)
+        s.discard(2)   # removes 2
+        s.discard(99)  # does nothing, no error
+        ```
         """
         try:
             self._data.pop(value)
@@ -622,5 +713,14 @@ struct Set[T: KeyElement, H: Hasher = default_hasher](
 
         This method modifies the set in-place, removing all of its elements.
         After calling this method, the set will be empty.
+
+        Example:
+        ```mojo
+        from std.collections import Set
+
+        var s = Set[Int](1, 2, 3)
+        s.clear()
+        print(len(s))  # 0
+        ```
         """
         self._data.clear()


### PR DESCRIPTION
Partial fix for #3572

## Summary
- Adds examples to 11 `Set` methods: `__contains__`, `add`, `remove`, `union`, `intersection`, `difference`, `issubset`, `isdisjoint`, `symmetric_difference`, `discard`, `clear`

## Testing
- `./bazelw test //mojo/stdlib/std:std.docs_test` — passes
- `./bazelw run //:lint` — passes

## Checklist
- [x] PR is small and focused
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an `Assisted-by:` trailer in my commit message or this PR description (see [AI Tool Use Policy](../AI_TOOL_POLICY.md))