### PR TITLE
[stdlib] Add docstring examples for os module functions (listdir, remove, mkdi…

### DIFF
--- a/mojo/stdlib/std/os/os.mojo
+++ b/mojo/stdlib/std/os/os.mojo
@@ -222,6 +222,15 @@ def listdir[PathLike: os.PathLike](path: PathLike) raises -> List[String]:
 
     Raises:
         If the operation fails.
+
+    Example:
+    ```mojo
+    from std.os import listdir
+
+    var entries = listdir("/tmp")
+    for entry in entries:
+        print(entry[])
+    ```
     """
     var dir = _DirHandle(path.__fspath__())
     return dir.list()
@@ -342,6 +351,13 @@ def remove[PathLike: os.PathLike](path: PathLike) raises:
 
     Raises:
         If the operation fails.
+
+    Example:
+    ```mojo
+    from std.os import remove
+
+    # remove("my_temp_file.txt")  # deletes the file
+    ```
     """
     var fspath = path.__fspath__()
     var error = external_call["unlink", Int32](
@@ -477,6 +493,15 @@ def mkdir[PathLike: os.PathLike](path: PathLike, mode: Int = 0o777) raises:
 
     Raises:
         If the operation fails.
+
+    Example:
+    ```mojo
+    from std.os import mkdir, rmdir
+
+    mkdir("/tmp/my_new_dir")
+    # ... use the directory ...
+    rmdir("/tmp/my_new_dir")
+    ```
     """
 
     var fspath = path.__fspath__()
@@ -504,6 +529,13 @@ def makedirs[
 
     Raises:
         If the operation fails.
+
+    Example:
+    ```mojo
+    from std.os import makedirs
+
+    makedirs("/tmp/a/b/c", exist_ok=True)  # creates all intermediate dirs
+    ```
     """
     var head, tail = split(path)
     if not tail:
@@ -543,6 +575,14 @@ def rmdir[PathLike: os.PathLike](path: PathLike) raises:
 
     Raises:
         If the operation fails.
+
+    Example:
+    ```mojo
+    from std.os import mkdir, rmdir
+
+    mkdir("/tmp/my_temp_dir")
+    rmdir("/tmp/my_temp_dir")  # removes the empty directory
+    ```
     """
     var fspath = path.__fspath__()
     var error = external_call["rmdir", Int32](


### PR DESCRIPTION
## Summary
5 public functions in std.os had no usage examples in their docstrings: listdir, remove, mkdir, makedirs, rmdir. No logic changes — docstrings only.

## Testing

./bazelw test //mojo/stdlib/std:std.docs_test — passes, all docstring examples compile

## Checklist

- [x] PR is small and focused — consider splitting larger changes into a
      sequence of smaller PRs
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description
      (see [AI Tool Use Policy](../AI_TOOL_POLICY.md))
