### PR TITLE
[stdlib] Add docstring example to swap function

### DIFF
--- a/mojo/stdlib/std/builtin/swap.mojo
+++ b/mojo/stdlib/std/builtin/swap.mojo
@@ -26,6 +26,15 @@ def swap[T: Movable](mut lhs: T, mut rhs: T):
     Args:
         lhs: Argument value swapped with rhs.
         rhs: Argument value swapped with lhs.
+
+    Example:
+    ```mojo
+    var a = 1
+    var b = 2
+    swap(a, b)
+    print(a)  # 2
+    print(b)  # 1
+    ```
     """
     var tmp = lhs^
     lhs = rhs^


### PR DESCRIPTION
## Summary
Add docstring example to `swap` showing basic value swapping. No logic changes — docstrings only.
Partial fix for #3572.
## Testing
./bazelw test //mojo/stdlib/std:std.docs_test — all tests pass
## Checklist
- [x] PR is small and focused
- [x] I ran ./bazelw run format
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an Assisted-by: trailer in my commit message or this PR description