### PR TITLE
[CI] Fix lint workflow to fetch origin/main for diff base

### DIFF
--- a/.github/workflows/test_pre_commit.yml
+++ b/.github/workflows/test_pre_commit.yml
@@ -39,6 +39,12 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+
+      - name: Fetch origin/main for lint diff base
+        run: |
+          git fetch origin main:refs/remotes/origin/main
 
       - name: Run lint
         run: |


### PR DESCRIPTION
Fixes #6656

Since commit 317eb29535, lint runs in fast mode and requires `origin/main` to compute the diff base. GitHub Actions checkout doesn't fetch it by default, causing contributor PRs to fail lint.

This adds `fetch-depth: 0` and explicitly fetches `origin/main` before running lint.