### PR TITLE
[Kernels] Gate fused_token_sampling_gpu all-NaN-row check behind ASSERT=all

### DIFF
--- a/max/kernels/src/nn/topk.mojo
+++ b/max/kernels/src/nn/topk.mojo
@@ -12,6 +12,7 @@
 # ===----------------------------------------------------------------------=== #
 """Provides top-K selection kernels using warp- and block-level reductions for CPU and GPU."""
 
+from std.builtin.debug_assert import ASSERT_MODE
 from std.math import ceildiv, exp, iota
 from std.math.uutils import ufloordiv, udivmod
 from std.memory import ThinAllocation, alloc, dealloc
@@ -1964,9 +1965,6 @@ def fused_token_sampling_gpu[
         coord_to_index_list(input.layout.shape_coord())
     )
 
-    # for validation
-    var batch_size = input_shape[0]
-
     @parameter
     def trace_information() -> String:
         return String(";").join(
@@ -2035,35 +2033,58 @@ def fused_token_sampling_gpu[
             row_major(Coord(out_vals_shape)),
         )
 
-        var valid_buf = ctx.enqueue_create_buffer[DType.int8](batch_size)
-        ctx.enqueue_memset(valid_buf, 1)  # 1 for True
+        # All-NaN-row check: the host readback syncs the device on every
+        # call, so compile it in only at the "all" assert level, like the
+        # LayoutTensor bounds checks.
+        comptime if ASSERT_MODE == "all":
+            var batch_size = input_shape[0]
+            var valid_buf = ctx.enqueue_create_buffer[DType.int8](batch_size)
+            ctx.enqueue_memset(valid_buf, 1)  # 1 for True
 
-        topk_gpu[sampling=True, largest=True](
-            ctx,
-            adjusted_max_k,
-            input,
-            out_vals,
-            out_idxs,
-            k=k,
-            temperature=temperature,
-            top_p=top_p,
-            min_p=min_p,
-            block_size=block_size,
-            num_blocks_per_input=num_blocks_per_input,
-            seed=seed,
-            valid=rebind[UnsafePointer[Int8, MutAnyOrigin]](
-                valid_buf.unsafe_ptr()
-            ),
-        )
-        var valid_host = ctx.enqueue_create_host_buffer[DType.int8](batch_size)
-        ctx.enqueue_copy(valid_host, valid_buf)
-        ctx.synchronize()
+            topk_gpu[sampling=True, largest=True](
+                ctx,
+                adjusted_max_k,
+                input,
+                out_vals,
+                out_idxs,
+                k=k,
+                temperature=temperature,
+                top_p=top_p,
+                min_p=min_p,
+                block_size=block_size,
+                num_blocks_per_input=num_blocks_per_input,
+                seed=seed,
+                valid=rebind[UnsafePointer[Int8, MutAnyOrigin]](
+                    valid_buf.unsafe_ptr()
+                ),
+            )
+            var valid_host = ctx.enqueue_create_host_buffer[DType.int8](
+                batch_size
+            )
+            ctx.enqueue_copy(valid_host, valid_buf)
+            ctx.synchronize()
 
-        for i in range(batch_size):
-            if not valid_host[i]:
-                raise Error("NaN logits detected in batch row " + String(i))
+            for i in range(batch_size):
+                if not valid_host[i]:
+                    raise Error("NaN logits detected in batch row " + String(i))
 
-        _ = valid_buf^
+            _ = valid_buf^
+        else:
+            topk_gpu[sampling=True, largest=True](
+                ctx,
+                adjusted_max_k,
+                input,
+                out_vals,
+                out_idxs,
+                k=k,
+                temperature=temperature,
+                top_p=top_p,
+                min_p=min_p,
+                block_size=block_size,
+                num_blocks_per_input=num_blocks_per_input,
+                seed=seed,
+            )
+
         _ = out_vals_buf^
 
 


### PR DESCRIPTION
`fused_token_sampling_gpu`'s small-k path does a host readback and a full `ctx.synchronize()` on every call to detect all-NaN logits rows, a whole-device round trip once per decode step. Gates the check behind `ASSERT_MODE == "all"` (the same gating as the LayoutTensor bounds checks); the default path samples without validity tracking or sync. The kernel already guards valid writes behind `if valid:`.

B200, Gemma-4-31B-IT-NVFP4 single-request greedy decode, vs the 26.5.0.dev20260715 pin: step time 10.5475 -> 8.6619 ms (-17.88%), GPU idle per step 2.281 -> 0.138 ms, byte-identical greedy output. Non-speculative scope; under MTP the site fires about once per request, not per step.

## Test plan

`test_topk_gpu.mojo.test` and `test_topk_gpu_fi.mojo.test` pass on B200 (`--config=prebuilt-mojo`); the site compiles with the default defines (check compiled out) and with `-D ASSERT=all` (check compiled in). E2E numbers are queued for re-measurement on current main.
