### PR TITLE
[Kernels] Add Gemma-4-31B-IT-NVFP4 MLP decode rows to SM100 NVFP4 tuning table

### DIFF
--- a/max/kernels/src/linalg/matmul/gpu/sm100_structured/default/tuning_configs.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm100_structured/default/tuning_configs.mojo
@@ -2091,6 +2091,48 @@ def _get_tuning_list_sm100_nvfp4() -> List[TuningConfigSM100]:
         # index: [0]
         TuningConfigSM100(
             M=1,
+            M_end=2,
+            N=5376,
+            K=21504,
+            mma_shape=Index(256, 16, 32),
+            cta_group=2,
+            cluster_shape=Index(2, 1, 1),
+            block_swizzle_size=8,
+            rasterize_order=RasterOrder(1),
+            swapAB=True,
+            k_group_size=2,
+            num_accum_pipeline_stages=1,
+            num_clc_pipeline_stages=0,
+            num_split_k=1,
+            num_pipeline_stages=0,
+            is_small_bn=True,
+            batch_size=1,
+        ),
+        # Automatically generated from [tuning_table_sm100_nvfp4.yaml]
+        # index: [1]
+        TuningConfigSM100(
+            M=1,
+            M_end=2,
+            N=43008,
+            K=5376,
+            mma_shape=Index(128, 8, 32),
+            cta_group=1,
+            cluster_shape=Index(1, 1, 1),
+            block_swizzle_size=8,
+            rasterize_order=RasterOrder(1),
+            swapAB=True,
+            k_group_size=3,
+            num_accum_pipeline_stages=1,
+            num_clc_pipeline_stages=0,
+            num_split_k=1,
+            num_pipeline_stages=0,
+            is_small_bn=True,
+            batch_size=1,
+        ),
+        # Automatically generated from [tuning_table_sm100_nvfp4.yaml]
+        # index: [2]
+        TuningConfigSM100(
+            M=1,
             M_end=17,
             N=18432,
             K=7168,
@@ -2109,7 +2151,7 @@ def _get_tuning_list_sm100_nvfp4() -> List[TuningConfigSM100]:
             batch_size=1,
         ),
         # Automatically generated from [tuning_table_sm100_nvfp4.yaml]
-        # index: [1]
+        # index: [3]
         TuningConfigSM100(
             M=17,
             M_end=33,
@@ -2130,7 +2172,7 @@ def _get_tuning_list_sm100_nvfp4() -> List[TuningConfigSM100]:
             batch_size=1,
         ),
         # Automatically generated from [tuning_table_sm100_nvfp4.yaml]
-        # index: [2]
+        # index: [4]
         TuningConfigSM100(
             M=32,
             M_end=129,
@@ -2151,7 +2193,7 @@ def _get_tuning_list_sm100_nvfp4() -> List[TuningConfigSM100]:
             batch_size=1,
         ),
         # Automatically generated from [tuning_table_sm100_nvfp4.yaml]
-        # index: [3]
+        # index: [5]
         TuningConfigSM100(
             M=65,
             M_end=129,
@@ -2172,7 +2214,7 @@ def _get_tuning_list_sm100_nvfp4() -> List[TuningConfigSM100]:
             batch_size=1,
         ),
         # Automatically generated from [tuning_table_sm100_nvfp4.yaml]
-        # index: [4]
+        # index: [6]
         TuningConfigSM100(
             M=2,
             M_end=32,
@@ -2193,7 +2235,7 @@ def _get_tuning_list_sm100_nvfp4() -> List[TuningConfigSM100]:
             batch_size=1,
         ),
         # Automatically generated from [tuning_table_sm100_nvfp4.yaml]
-        # index: [5]
+        # index: [7]
         TuningConfigSM100(
             M=64,
             M_end=129,
@@ -2214,7 +2256,7 @@ def _get_tuning_list_sm100_nvfp4() -> List[TuningConfigSM100]:
             batch_size=1,
         ),
         # Automatically generated from [tuning_table_sm100_nvfp4.yaml]
-        # index: [6]
+        # index: [8]
         TuningConfigSM100(
             M=1,
             M_end=9,
@@ -2235,7 +2277,7 @@ def _get_tuning_list_sm100_nvfp4() -> List[TuningConfigSM100]:
             batch_size=1,
         ),
         # Automatically generated from [tuning_table_sm100_nvfp4.yaml]
-        # index: [7]
+        # index: [9]
         TuningConfigSM100(
             M=9,
             M_end=17,
@@ -2256,7 +2298,7 @@ def _get_tuning_list_sm100_nvfp4() -> List[TuningConfigSM100]:
             batch_size=1,
         ),
         # Automatically generated from [tuning_table_sm100_nvfp4.yaml]
-        # index: [8]
+        # index: [10]
         TuningConfigSM100(
             M=17,
             M_end=25,
@@ -2277,7 +2319,7 @@ def _get_tuning_list_sm100_nvfp4() -> List[TuningConfigSM100]:
             batch_size=1,
         ),
         # Automatically generated from [tuning_table_sm100_nvfp4.yaml]
-        # index: [9]
+        # index: [11]
         TuningConfigSM100(
             M=25,
             M_end=33,
@@ -2298,7 +2340,7 @@ def _get_tuning_list_sm100_nvfp4() -> List[TuningConfigSM100]:
             batch_size=1,
         ),
         # Automatically generated from [tuning_table_sm100_nvfp4.yaml]
-        # index: [10]
+        # index: [12]
         TuningConfigSM100(
             M=33,
             M_end=65,
@@ -2319,7 +2361,7 @@ def _get_tuning_list_sm100_nvfp4() -> List[TuningConfigSM100]:
             batch_size=1,
         ),
         # Automatically generated from [tuning_table_sm100_nvfp4.yaml]
-        # index: [11]
+        # index: [13]
         TuningConfigSM100(
             M=65,
             M_end=69,

--- a/max/kernels/src/linalg/matmul/gpu/sm100_structured/default/tuning_table_sm100_nvfp4.yaml
+++ b/max/kernels/src/linalg/matmul/gpu/sm100_structured/default/tuning_table_sm100_nvfp4.yaml
@@ -25,8 +25,8 @@ defaults: &defaults
   BATCH_SIZE: 1
 params:
 # Gemma-4-31B-IT-NVFP4 (hidden 5376, intermediate 21504) MLP, decode M=1.
-# The small-M fallback picks k_group_size by K-iteration parity and never
-# tries the legal, faster kg=3 for gate_up's 21 K-iterations.
+# The small-M fallback only considers k_group_size in {4, 2, 1} based on num_k_iters divisibility,
+# so for gate_up's 21 k-iters it never tries the legal, faster kg=3.
 - <<: *defaults
   M: 1
   M_END: 2

--- a/max/kernels/src/linalg/matmul/gpu/sm100_structured/default/tuning_table_sm100_nvfp4.yaml
+++ b/max/kernels/src/linalg/matmul/gpu/sm100_structured/default/tuning_table_sm100_nvfp4.yaml
@@ -24,6 +24,38 @@ defaults: &defaults
   IS_SMALL_BN: false
   BATCH_SIZE: 1
 params:
+# Gemma-4-31B-IT-NVFP4 (hidden 5376, intermediate 21504) MLP, decode M=1.
+# The small-M fallback picks k_group_size by K-iteration parity and never
+# tries the legal, faster kg=3 for gate_up's 21 K-iterations.
+- <<: *defaults
+  M: 1
+  M_END: 2
+  N: 5376
+  K: 21504
+  MMA_M: 256
+  MMA_N: 16
+  CLUSTER_X: 2
+  CLUSTER_Y: 1
+  BLOCK_SWIZZLE_SIZE: 8
+  K_GROUP_SIZE: 2
+  NUM_ACCUM_PIPELINE_STAGES: 1
+  NUM_CLC_PIPELINE_STAGES: 0
+  IS_SMALL_BN: true
+- <<: *defaults
+  M: 1
+  M_END: 2
+  N: 43008
+  K: 5376
+  MMA_M: 128
+  MMA_N: 8
+  CTA_GROUP: 1
+  CLUSTER_X: 1
+  CLUSTER_Y: 1
+  BLOCK_SWIZZLE_SIZE: 8
+  K_GROUP_SIZE: 3
+  NUM_ACCUM_PIPELINE_STAGES: 1
+  NUM_CLC_PIPELINE_STAGES: 0
+  IS_SMALL_BN: true
 - <<: *defaults
   M: 1
   M_END: 17

--- a/max/kernels/src/linalg/matmul/gpu/sm100_structured/default/tuning_table_sm100_nvfp4.yaml
+++ b/max/kernels/src/linalg/matmul/gpu/sm100_structured/default/tuning_table_sm100_nvfp4.yaml
@@ -24,6 +24,38 @@ defaults: &defaults
   IS_SMALL_BN: false
   BATCH_SIZE: 1
 params:
+# Gemma-4-31B-IT-NVFP4 (hidden 5376, intermediate 21504) MLP, decode M=1.
+# The small-M fallback only considers k_group_size in {4, 2, 1} based on num_k_iters divisibility,
+# so for gate_up's 21 k-iters it never tries the legal, faster kg=3.
+- <<: *defaults
+  M: 1
+  M_END: 2
+  N: 5376
+  K: 21504
+  MMA_M: 256
+  MMA_N: 16
+  CLUSTER_X: 2
+  CLUSTER_Y: 1
+  BLOCK_SWIZZLE_SIZE: 8
+  K_GROUP_SIZE: 2
+  NUM_ACCUM_PIPELINE_STAGES: 1
+  NUM_CLC_PIPELINE_STAGES: 0
+  IS_SMALL_BN: true
+- <<: *defaults
+  M: 1
+  M_END: 2
+  N: 43008
+  K: 5376
+  MMA_M: 128
+  MMA_N: 8
+  CTA_GROUP: 1
+  CLUSTER_X: 1
+  CLUSTER_Y: 1
+  BLOCK_SWIZZLE_SIZE: 8
+  K_GROUP_SIZE: 3
+  NUM_ACCUM_PIPELINE_STAGES: 1
+  NUM_CLC_PIPELINE_STAGES: 0
+  IS_SMALL_BN: true
 - <<: *defaults
   M: 1
   M_END: 17

--- a/max/kernels/test/gpu/linalg/test_matmul_sm100_block_scaled_fp4_small_bn.mojo
+++ b/max/kernels/test/gpu/linalg/test_matmul_sm100_block_scaled_fp4_small_bn.mojo
@@ -237,7 +237,7 @@ def run_matmul_sm100_block_scaled_fp4_small_bn_suite[
         comptime small_bn_umma = Index(128, 8, MMA_K)
 
         @__parameter
-        def test_small_bn[N: Int, K: Int]() raises:
+        def test_small_bn[N: Int, K: Int, k_group_size: Int = 2]() raises:
             test_blackwell_block_scaled_matmul_tma_umma_warp_specialized[
                 dtype,
                 dtype,
@@ -251,7 +251,7 @@ def run_matmul_sm100_block_scaled_fp4_small_bn_suite[
                 b_swizzle=swizzle,
                 block_swizzle_size=8,
                 swapAB=True,
-                k_group_size=2,
+                k_group_size=k_group_size,
                 num_clc_pipeline_stages=0,
                 SF_VECTOR_SIZE=SF_VECTOR_SIZE,
                 is_small_bn=True,
@@ -268,6 +268,7 @@ def run_matmul_sm100_block_scaled_fp4_small_bn_suite[
         test_small_bn[13312, 16384]()  # Fused MLP.UpProj + MLP.GateProj
         test_small_bn[16384, 6656]()  # MLP.DownProj
         test_small_bn[7168, 16384]()  # Deepseek
+        test_small_bn[43008, 5376, 3]()  # Gemma-4-31B MLP.GateUpProj (fused)
 
         # Epilogue fusion tests: verify TileWriter's elementwise_lambda_fn path.
         print("\n--- Epilogue fusion tests ---")

--- a/max/kernels/test/gpu/linalg/test_matmul_sm100_block_scaled_fp4_small_bn_2sm.mojo
+++ b/max/kernels/test/gpu/linalg/test_matmul_sm100_block_scaled_fp4_small_bn_2sm.mojo
@@ -186,6 +186,28 @@ def run_matmul_sm100_block_scaled_fp4_small_bn_2sm_suite[
             is_small_bn=True,
         ](ctx, Idx[1], Idx[36864], Idx[128 * 28])
 
+        # Gemma-4-31B MLP.DownProj (M=1, N=5376, K=21504, k_group_size=2)
+        comptime gemma_block_tile = Index(128, 8, BK)
+        comptime gemma_umma = Index(256, 16, MMA_K)
+        test_blackwell_block_scaled_matmul_tma_umma_warp_specialized[
+            dtype,
+            dtype,
+            out_dtype,
+            scales_dtype,
+            gemma_block_tile,
+            gemma_umma,
+            cluster_shape=StaticTuple[Int32, 3](Int32(2), 1, 1),
+            cta_group=2,
+            a_swizzle=swizzle,
+            b_swizzle=swizzle,
+            block_swizzle_size=8,
+            swapAB=True,
+            k_group_size=2,
+            num_clc_pipeline_stages=0,
+            SF_VECTOR_SIZE=SF_VECTOR_SIZE,
+            is_small_bn=True,
+        ](ctx, Idx[1], Idx[5376], Idx[21504])
+
         # Epilogue fusion tests: verify TileWriter's elementwise_lambda_fn path
         # with 2SM (cta_group=2).
         print("\n--- 2SM Epilogue fusion tests ---")


### PR DESCRIPTION
Gemma-4-31B-IT-NVFP4's MLP decode shapes (down N=5376/K=21504, gate_up N=43008/K=5376, M=1) miss the SM100 NVFP4 tuning table, which carried DeepSeek shapes only, and fall to the hardcoded small-M fallback in `block_scaled_dispatch.mojo`. The fallback picks `k_group_size` by K-iteration parity, so for gate_up's 21 K-iterations it never tries kg=3, which is faster. Adds the two tuned rows; `tuning_configs.mojo` regenerated with tuning_codegen.

B200, vs the 26.5.0.dev20260715 pin fallback: down -19.6% (16.8 us), gate_up -8.4% (27.0 us); about 8% single-request decode throughput combined.

## Test plan

`sm100_nvfp4_tuning_codegen_test` passes, locally (`--check`) and on a B200 host (`./bazelw test --config=prebuilt-mojo`). 