### PR TITLE
[MAX] Add DeviceContext identity equality

### DIFF
--- a/max/kernels/test/gpu/device_context/test_device_context_cpu.mojo
+++ b/max/kernels/test/gpu/device_context/test_device_context_cpu.mojo
@@ -13,7 +13,7 @@
 
 from max.gpu.host import DeviceContext, DeviceContextArray
 from std.memory import alloc
-from std.testing import assert_equal, assert_true
+from std.testing import assert_equal, assert_false, assert_true
 
 
 def test_empty_func(ctx: DeviceContext) raises:
@@ -187,6 +187,24 @@ def test_device_context_array(ctx: DeviceContext) raises:
     assert_equal(direct[0].api(), ctx.api())
 
 
+def test_context_equality(ctx: DeviceContext) raises:
+    # A copy of the same context refers to the same underlying runtime
+    # context, so it compares equal.
+    var copy = ctx
+    assert_true(copy == ctx)
+    assert_false(copy != ctx)
+
+    # A separately constructed context on the same device is a different
+    # runtime context, even though the device ID is identical.
+    var fresh = DeviceContext(api="cpu")
+    assert_false(fresh == ctx)
+    assert_true(fresh != ctx)
+
+    # Copies of the same fresh context are equal to each other.
+    var fresh_copy = fresh
+    assert_true(fresh_copy == fresh)
+
+
 def main() raises:
     with DeviceContext(api="cpu") as ctx:
         test_empty_func(ctx)
@@ -199,3 +217,4 @@ def main() raises:
         test_func_then_range(ctx)
         test_two_ranges_sequential(ctx)
         test_device_context_array(ctx)
+        test_context_equality(ctx)

--- a/max/mojo/max/gpu/host/device_context.mojo
+++ b/max/mojo/max/gpu/host/device_context.mojo
@@ -3904,6 +3904,35 @@ struct DeviceContext(ImplicitlyCopyable, RegisterPassable, _FunctionEnqueuer):
             _DeviceContextPtr[mut=True],
         ](self._handle)
 
+    def __eq__(self, other: Self) -> Bool:
+        """Returns `True` if `self` and `other` refer to the same underlying
+        runtime context (same internal handle), not merely the same device ID.
+
+        Two separately constructed contexts on the same device are considered
+        different, while copies of the same context compare equal. The
+        `_owning` flag is not part of identity: a non-owning wrapper around the
+        same native context compares equal to the owning one.
+
+        Args:
+            other: The other `DeviceContext` to compare.
+
+        Returns:
+            `True` if `self` and `other` wrap the same native context.
+        """
+        return self._handle == other._handle
+
+    def __ne__(self, other: Self) -> Bool:
+        """Returns `True` if `self` and `other` refer to different runtime
+        contexts.
+
+        Args:
+            other: The other `DeviceContext` to compare.
+
+        Returns:
+            `True` if `self` and `other` wrap different native contexts.
+        """
+        return not self == other
+
     def __enter__(var self) -> Self:
         """Enables the use of DeviceContext in a 'with' statement context manager.
 


### PR DESCRIPTION
## Linked issue

Related to #6458

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [x] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

`DeviceContext` has no equality operators, so two contexts can only be compared by device ID (`api()`). There's no way to tell whether two contexts wrap the same underlying runtime context — e.g. after copying a context or passing it by value, or when deciding whether two contexts on the same device are actually the same resource. Issue #6458 requests a public equality API.

## What changed

- Add `__eq__` / `__ne__` to `DeviceContext` in `max/mojo/max/gpu/host/device_context.mojo`. Equality is defined on the internal native `_handle`: copies of the same context compare equal; separately constructed contexts on the same device compare unequal. `_owning` is deliberately excluded from identity, so a non-owning wrapper around the same native context compares equal to the owning one.
- Add `test_context_equality` to `test_device_context_cpu.mojo` covering copies, freshly constructed contexts, and the `!=` negation. It runs from `main()` alongside the existing tests.

## Testing

Not run locally — this environment has no GPU/toolchain, so the change could not be compiled or executed here. Coverage is provided by the CI bazel `mojo_test` job, which compiles and runs `test_device_context_cpu.mojo.test`, including the new `test_context_equality`.

## Scope note

This covers the old driver only. The HAL/neo-driver `DeviceContext` also lacks equality; a matching patch (comparing the underlying `Stream` via `__is__`) belongs in `mojo/stdlib/std/gpu/host/_device_context_hal.mojo`, which is not present in this checkout. Issue #6458 is therefore left open for that half.

Assisted-by: AI