### PR TITLE
[Mojo-compiler] Fix kgen.variant LLVM lowering hang

### DIFF
--- a/KGEN/lib/KGENToLLVM/LLVMLoweringUtils.cpp
+++ b/KGEN/lib/KGENToLLVM/LLVMLoweringUtils.cpp
@@ -377,6 +377,16 @@ POPToLLVMTypeConverter::POPToLLVMTypeConverter(TargetInfoAttr target)
           curAlignAndMember.first >= maxAlignAndType.first)
         maxAlignAndType = curAlignAndMember;
     }
+
+    // The LLVM alloc size of a converted member can be smaller than the KGEN
+    // alloc size of the member itself (e.g. `simd<N, bool>` is one byte per
+    // lane in KGEN, but converts to a bit-packed `vector<N x i1>`). All
+    // KGEN-level layout (sizeof, struct field offsets, the discriminant
+    // offset of `!kgen.variant`) follows the KGEN metric, so the union
+    // storage must be at least as large as KGEN says it is.
+    if (std::optional<int64_t> kgenSize = unionType.getTypeSize(getTarget()))
+      maxSize = std::max(maxSize, *kgenSize);
+
     if (maxSize == 0)
       return LLVM::LLVMStructType::getLiteral(&getContext(), {});
 

--- a/KGEN/test/kgen/kgen-to-llvm/union.mlir
+++ b/KGEN/test/kgen/kgen-to-llvm/union.mlir
@@ -1,0 +1,26 @@
+// RUN: kgen-opt -lower-kgen-to-llvm %s | FileCheck %s
+
+// Test lowering of `!pop.union` to LLVM.
+
+module attributes {M.target_info = #M.target<triple="", arch="", features="", data_layout="", simd_bit_width=128>} {
+
+// CHECK-LABEL: @union_bool_simd_with_empty_member
+// CHECK-SAME: !llvm.struct<(i16)>
+kgen.func @union_bool_simd_with_empty_member(%arg0: !pop.union<!kgen.struct<()>, !kgen.simd<2, bool>>) {
+  kgen.return
+}
+
+// CHECK-LABEL: @union_bool_simd
+// CHECK-SAME: !llvm.struct<(i16)>
+kgen.func @union_bool_simd(%arg0: !pop.union<!kgen.simd<2, bool>>) {
+  kgen.return
+}
+
+// A wider member still dominates the layout.
+// CHECK-LABEL: @union_bool_simd_with_wider_member
+// CHECK-SAME: !llvm.struct<(i64)>
+kgen.func @union_bool_simd_with_wider_member(%arg0: !pop.union<index, !kgen.simd<2, bool>>) {
+  kgen.return
+}
+
+}


### PR DESCRIPTION
remLen could underflow if maxSize is less than the kgen defined size. Causing a compiler hang as it would result in the storage type being an absurdly large array.

This issue appeared when using a `Optional[SIMD[DType.bool, 2]]` type.

FYI, this appears to be reproducible in Mojo 1.0

<!--
Thanks for submitting a pull request! Your contribution is appreciated.

Before you open this PR, please make sure the change has been discussed and
agreed upon with a maintainer. For anything beyond a trivial fix (typo,
one-line bug fix, doc tweak), we ask that you first open a GitHub issue or
proposal and get a maintainer's go-ahead. This helps us avoid situations
where a PR sits unreviewed because the change isn't aligned with the
team's direction. See our [contributor guide](https://github.com/modular/modular/blob/main/CONTRIBUTING.md) for
details.
-->

## Linked issue

<!--
Replace `NNN` with the issue number. For anything non-trivial, a linked
issue that a maintainer has agreed to is expected before review.

- Trivial fix (typo, comment, small doc fix): you can write "N/A — trivial".
- Everything else: `Fixes #NNN` or `Related to #NNN`.
-->

Fixes #6921

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

<!--
Why is this change needed? What problem does it solve, or what use case
does it enable? If this is a bug fix, describe the bug and how a user
would hit it. If this is a new feature, explain the user-facing value.

Please write prose here — don't just restate the PR title.
-->

Fixes a problematic compiler bug on a type that is simple enough to be encountered elsewhere in the wild

## What changed

<!--
Describe the change at a high level. Call out anything non-obvious: API
changes, behavior changes, performance characteristics, or tricky
implementation details.
-->

Change llvm lowering path for POP::UnionType to avoid arithmetic underflow resulting in union storage size becoming very large.

## Testing

<!--
Describe how you validated your changes.

- Code changes: what tests did you run, and what were the results? Did
  you add a new test that would have caught the bug?
- Performance changes: include before/after numbers from a benchmark.
- Documentation: describe how you verified accuracy (built the docs,
  ran the example, etc.).
-->

Ran compiler and stdlib tests. Added new compiler test case

## Checklist

- [x] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description (see
      [AI Tool Use Policy](https://github.com/modular/modular/blob/main/AI_TOOL_POLICY.md))
